### PR TITLE
Resolving version dependency for HA Core 2024.12.0

### DIFF
--- a/custom_components/smartrent/manifest.json
+++ b/custom_components/smartrent/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/ZacheryThomas/homeassistant-smartrent/issues",
   "requirements": [
-    "smartrent-py==0.4.4"
+    "smartrent-py==0.4.5"
   ],
   "version": "0.4.6"
 }


### PR DESCRIPTION
Integration broke upon upgrade to HA Core 2024.12.0 due to unresolveable version dependency on websockets. Changed smartrent-py requirement to 0.4.5