### PR TITLE
init: Persist refresh token to avoid OTP on HA restart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,27 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  release_zip_file:
-    name: Publish HACS zip file asset
+  create_release:
+    name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      # Pack the smartrent dir as a zip and upload to the release
       - name: ZIP smartrent Dir
-        if: ${{ github.event_name == 'release' }}
         run: |
           cd ${{ github.workspace }}/custom_components/smartrent
           zip smartrent.zip -r ./
 
-      - name: Upload zip to release
-        uses: svenstaro/upload-release-action@v1-release
-        if: ${{ github.event_name == 'release' }}
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ github.workspace }}/custom_components/smartrent/smartrent.zip
-          asset_name: smartrent.zip
-          tag: ${{ github.ref }}
-          overwrite: true
+          generate_release_notes: true
+          files: ${{ github.workspace }}/custom_components/smartrent/smartrent.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# Build
 __pycache__
+
+# Misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ You should be able to now load the integration. This can be done by going to `Co
 
 You should be able to search for SmartRent and then enter your email and password in the popup.
 
-[license-shield]: https://img.shields.io/github/license/zacherythomas/homeassistant-smartrent.svg?style=for-the-badge
+[license-shield]: https://img.shields.io/github/license/abipalli/homeassistant-smartrent.svg?style=for-the-badge
 [hacs-shield]: https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge
 [black-shield]: https://img.shields.io/badge/code%20style-black-000000.svg?style=for-the-badge
 
-[releases-shield]: https://img.shields.io/github/release/zacherythomas/homeassistant-smartrent.svg?style=for-the-badge
-[releases]: https://github.com/zacherythomas/homeassistant-smartrent/releases
-[commits-shield]: https://img.shields.io/github/commit-activity/y/zacherythomas/homeassistant-smartrent.svg?style=for-the-badge
-[commits]: https://github.com/zacherythomas/homeassistant-smartrent/commits/master
-[downloads-shield]: https://img.shields.io/github/downloads/zacherythomas/homeassistant-smartrent/total?color=green&style=for-the-badge
+[releases-shield]: https://img.shields.io/github/release/abipalli/homeassistant-smartrent.svg?style=for-the-badge
+[releases]: https://github.com/abipalli/homeassistant-smartrent/releases
+[commits-shield]: https://img.shields.io/github/commit-activity/y/abipalli/homeassistant-smartrent.svg?style=for-the-badge
+[commits]: https://github.com/abipalli/homeassistant-smartrent/commits/main
+[downloads-shield]: https://img.shields.io/github/downloads/abipalli/homeassistant-smartrent/total?color=green&style=for-the-badge

--- a/custom_components/smartrent/__init__.py
+++ b/custom_components/smartrent/__init__.py
@@ -100,6 +100,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
+    if entry.entry_id not in hass.data.get(DOMAIN, {}):
+        return True
+
     unloaded = all(
         await asyncio.gather(
             *[

--- a/custom_components/smartrent/__init__.py
+++ b/custom_components/smartrent/__init__.py
@@ -93,7 +93,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
 
 
@@ -107,8 +106,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             device.stop_updater()
 
     return unloaded
-
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload config entry."""
-    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/smartrent/__init__.py
+++ b/custom_components/smartrent/__init__.py
@@ -18,6 +18,7 @@ from smartrent.utils import InvalidAuthError
 
 from .const import (
     CONF_PASSWORD,
+    CONF_REFRESH_TOKEN,
     CONF_TOKEN,
     CONF_USERNAME,
     DOMAIN,
@@ -37,16 +38,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
     tfa_token = entry.data.get(CONF_TOKEN)
+    stored_refresh_token = entry.data.get(CONF_REFRESH_TOKEN)
 
     session = async_get_clientsession(hass)
     try:
-        api = await async_login(username, password, session, tfa_token=tfa_token)
+        if stored_refresh_token:
+            try:
+                api = API(username, password, session)
+                api.client._refresh_token = stored_refresh_token
+                await api.async_fetch_devices()
+                _LOGGER.info("Rehydrated auth using stored refresh token")
+            except InvalidAuthError:
+                _LOGGER.warning(
+                    "Stored refresh token rejected. Falling back to full login."
+                )
+                api = await async_login(username, password, session, tfa_token=tfa_token)
+        else:
+            api = await async_login(username, password, session, tfa_token=tfa_token)
     except InvalidAuthError as exception:
         raise ConfigEntryAuthFailed("Credentials expired!") from exception
     except ClientConnectorError as exception:
         raise ConfigEntryNotReady from exception
     except EOFError as exception:
         raise ConfigEntryAuthFailed("TFA not supplied. Please Reauth!") from exception
+
+    new_refresh_token = api.client._refresh_token
+    if new_refresh_token and new_refresh_token != stored_refresh_token:
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_REFRESH_TOKEN: new_refresh_token}
+        )
 
     hass.data[DOMAIN][entry.entry_id] = api
 
@@ -69,6 +89,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api: API = hass.data[DOMAIN][entry.entry_id]
     for device in api.get_device_list():
         device.stop_updater()
+
+    latest_refresh_token = api.client._refresh_token
+    if latest_refresh_token and latest_refresh_token != entry.data.get(CONF_REFRESH_TOKEN):
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_REFRESH_TOKEN: latest_refresh_token}
+        )
 
     if unloaded:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/smartrent/__init__.py
+++ b/custom_components/smartrent/__init__.py
@@ -29,6 +29,32 @@ from .const import (
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
+def _install_token_persist_hook(
+    hass: HomeAssistant, entry: ConfigEntry, api: API
+) -> None:
+    """Wrap the client's token refresh so every rotation is persisted immediately.
+
+    The smartrent-py library rotates the refresh token on every call to
+    ``_async_refresh_token`` (WebSocket reconnects, retries, etc.).  The old
+    token is invalidated server-side, so we must persist the new one right away
+    — waiting for ``async_unload_entry`` is not sufficient because a crash or
+    power-off would leave a stale (invalidated) token on disk.
+    """
+    client = api.client
+    original_refresh = client._async_refresh_token
+
+    async def _persist_after_refresh() -> None:
+        await original_refresh()
+        new_token = client._refresh_token
+        if new_token and new_token != entry.data.get(CONF_REFRESH_TOKEN):
+            hass.config_entries.async_update_entry(
+                entry, data={**entry.data, CONF_REFRESH_TOKEN: new_token}
+            )
+            _LOGGER.debug("Persisted rotated refresh token")
+
+    client._async_refresh_token = _persist_after_refresh
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up this integration using UI."""
     if hass.data.get(DOMAIN) is None:
@@ -44,11 +70,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     try:
         if stored_refresh_token:
             try:
-                api = API(username, password, session)
+                api = API(username, password, session, tfa_token=tfa_token)
                 api.client._refresh_token = stored_refresh_token
                 await api.async_fetch_devices()
                 _LOGGER.info("Rehydrated auth using stored refresh token")
-            except InvalidAuthError:
+            except (InvalidAuthError, KeyError):
                 _LOGGER.warning(
                     "Stored refresh token rejected. Falling back to full login."
                 )
@@ -62,11 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     except EOFError as exception:
         raise ConfigEntryAuthFailed("TFA not supplied. Please Reauth!") from exception
 
-    new_refresh_token = api.client._refresh_token
-    if new_refresh_token and new_refresh_token != stored_refresh_token:
-        hass.config_entries.async_update_entry(
-            entry, data={**entry.data, CONF_REFRESH_TOKEN: new_refresh_token}
-        )
+    _install_token_persist_hook(hass, entry, api)
 
     hass.data[DOMAIN][entry.entry_id] = api
 
@@ -89,12 +111,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api: API = hass.data[DOMAIN][entry.entry_id]
     for device in api.get_device_list():
         device.stop_updater()
-
-    latest_refresh_token = api.client._refresh_token
-    if latest_refresh_token and latest_refresh_token != entry.data.get(CONF_REFRESH_TOKEN):
-        hass.config_entries.async_update_entry(
-            entry, data={**entry.data, CONF_REFRESH_TOKEN: latest_refresh_token}
-        )
 
     if unloaded:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/smartrent/__init__.py
+++ b/custom_components/smartrent/__init__.py
@@ -4,7 +4,6 @@ Custom integration to integrate integration_blueprint with Home Assistant.
 For more details about this integration, please refer to
 https://github.com/custom-components/integration_blueprint
 """
-import asyncio
 import logging
 
 from aiohttp.client_exceptions import ClientConnectorError
@@ -94,34 +93,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    entry.add_update_listener(async_reload_entry)
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
-    if entry.entry_id not in hass.data.get(DOMAIN, {}):
-        return True
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    unloaded = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, platform)
-                for platform in PLATFORMS
-            ]
-        )
-    )
-    api: API = hass.data[DOMAIN][entry.entry_id]
-    for device in api.get_device_list():
-        device.stop_updater()
-
-    if unloaded:
-        hass.data[DOMAIN].pop(entry.entry_id)
+    api: API | None = hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+    if api:
+        for device in api.get_device_list():
+            device.stop_updater()
 
     return unloaded
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/smartrent/const.py
+++ b/custom_components/smartrent/const.py
@@ -5,5 +5,6 @@ CONFIGURATION_URL = "https://control.smartrent.com/login"
 CONF_PASSWORD = "password"
 CONF_USERNAME = "username"
 CONF_TOKEN = "token"
+CONF_REFRESH_TOKEN = "refresh_token"
 PLATFORMS = ["binary_sensor", "climate", "light", "lock", "sensor", "switch"]
 STARTUP_MESSAGE = f"Starting setup for {DOMAIN}"

--- a/custom_components/smartrent/manifest.json
+++ b/custom_components/smartrent/manifest.json
@@ -2,15 +2,15 @@
   "domain": "smartrent",
   "name": "SmartRent",
   "codeowners": [
-    "@zacherythomas"
+    "@abipalli"
   ],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/ZacheryThomas/homeassistant-smartrent",
+  "documentation": "https://github.com/abipalli/homeassistant-smartrent",
   "iot_class": "cloud_push",
-  "issue_tracker": "https://github.com/ZacheryThomas/homeassistant-smartrent/issues",
+  "issue_tracker": "https://github.com/abipalli/homeassistant-smartrent/issues",
   "requirements": [
-    "smartrent-py==0.5.2"
+    "smartrent-py==0.5.5"
   ],
   "version": "0.5.5"
 }

--- a/custom_components/smartrent/manifest.json
+++ b/custom_components/smartrent/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "smartrent-py==0.5.5"
   ],
-  "version": "0.5.5"
+  "version": "0.5.7"
 }

--- a/custom_components/smartrent/manifest.json
+++ b/custom_components/smartrent/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/abipalli/homeassistant-smartrent/issues",
   "requirements": [
-    "smartrent-py==0.5.5"
+    "smartrent-py==0.5.2"
   ],
   "version": "0.5.7"
 }

--- a/custom_components/smartrent/manifest.json
+++ b/custom_components/smartrent/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "smartrent-py==0.5.2"
   ],
-  "version": "0.5.7"
+  "version": "0.5.8"
 }

--- a/custom_components/smartrent/manifest.json
+++ b/custom_components/smartrent/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "smartrent-py==0.5.2"
   ],
-  "version": "0.6.1"
+  "version": "0.6.2"
 }

--- a/custom_components/smartrent/manifest.json
+++ b/custom_components/smartrent/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "smartrent-py==0.5.2"
   ],
-  "version": "0.6.0"
+  "version": "0.6.1"
 }

--- a/custom_components/smartrent/manifest.json
+++ b/custom_components/smartrent/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "smartrent-py==0.5.2"
   ],
-  "version": "0.5.8"
+  "version": "0.6.0"
 }


### PR DESCRIPTION
## Summary

- Persists the `refresh_token` from the SmartRent API client to the config entry after each login or unload
- On subsequent HA restarts, rehydrates auth from the stored refresh token instead of performing a full login — avoiding the need to re-enter a one-time password (OTP)
- Falls back gracefully to full username/password + OTP login if the stored token is rejected (e.g. expired or revoked)

## Motivation

Users with 2FA/OTP enabled are prompted to re-enter their OTP every time Home Assistant restarts, since the integration performs a fresh login on each `async_setup_entry`. Persisting the refresh token allows the integration to resume sessions silently.

## How it works

1. On `async_setup_entry`: if a `refresh_token` is stored in the config entry, construct the `API` object, inject the token directly into the underlying client, and attempt `async_fetch_devices()` to validate. On success, skip the full login. On `InvalidAuthError`, fall back to `async_login()`.
2. After a successful login (or token reuse): if the refresh token has changed, persist it to the config entry via `async_update_entry`.
3. On `async_unload_entry`: persist the latest refresh token before unloading, so the next startup always has the most recent token.

## Test plan

- [ ] Fresh install (no stored token): verify full login flow works as before
- [ ] Restart HA after initial login: verify auth succeeds without OTP prompt
- [ ] Invalidate stored token manually (edit `.storage/core.config_entries`), restart HA: verify fallback to full login + OTP
- [ ] Verify token is updated in config entry after re-login