### PR TITLE
Allow 2FA authentication to persist after HA restart

### DIFF
--- a/custom_components/smartrent/__init__.py
+++ b/custom_components/smartrent/__init__.py
@@ -18,6 +18,7 @@ from smartrent.utils import InvalidAuthError
 
 from .const import (
     CONF_PASSWORD,
+    CONF_REFRESH_TOKEN,
     CONF_TOKEN,
     CONF_USERNAME,
     DOMAIN,
@@ -26,6 +27,29 @@ from .const import (
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+
+
+def _persist_refresh_token(hass: HomeAssistant, entry: ConfigEntry, api: API) -> None:
+    """Save the client's current refresh token into the config entry."""
+    new_refresh_token = api.client._refresh_token
+    if new_refresh_token and new_refresh_token != entry.data.get(CONF_REFRESH_TOKEN):
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_REFRESH_TOKEN: new_refresh_token}
+        )
+
+
+async def _async_login_with_refresh_token(
+    entry: ConfigEntry, session, username, password, tfa_token
+) -> API:
+    """Try authenticating using a stored refresh token to avoid TFA prompts."""
+    refresh_token = entry.data.get(CONF_REFRESH_TOKEN)
+    if not refresh_token:
+        raise InvalidAuthError("No stored refresh token")
+
+    api = API(username, password, session, tfa_token=tfa_token)
+    api.client._refresh_token = refresh_token
+    await api.async_fetch_devices()
+    return api
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
@@ -39,14 +63,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     tfa_token = entry.data.get(CONF_TOKEN)
 
     session = async_get_clientsession(hass)
-    try:
-        api = await async_login(username, password, session, tfa_token=tfa_token)
-    except InvalidAuthError as exception:
-        raise ConfigEntryAuthFailed("Credentials expired!") from exception
-    except ClientConnectorError as exception:
-        raise ConfigEntryNotReady from exception
-    except EOFError as exception:
-        raise ConfigEntryAuthFailed("TFA not supplied. Please Reauth!") from exception
+    api = None
+
+    if entry.data.get(CONF_REFRESH_TOKEN):
+        try:
+            api = await _async_login_with_refresh_token(
+                entry, session, username, password, tfa_token
+            )
+            _LOGGER.debug("Authenticated using stored refresh token")
+        except (InvalidAuthError, ClientConnectorError, EOFError, Exception) as exc:
+            _LOGGER.warning(
+                "Refresh token login failed (%s), falling back to full login",
+                type(exc).__name__,
+            )
+            api = None
+
+    if api is None:
+        try:
+            api = await async_login(username, password, session, tfa_token=tfa_token)
+        except InvalidAuthError as exception:
+            raise ConfigEntryAuthFailed("Credentials expired!") from exception
+        except ClientConnectorError as exception:
+            raise ConfigEntryNotReady from exception
+        except EOFError as exception:
+            raise ConfigEntryAuthFailed(
+                "TFA not supplied. Please Reauth!"
+            ) from exception
+
+    _persist_refresh_token(hass, entry, api)
 
     hass.data[DOMAIN][entry.entry_id] = api
 
@@ -58,6 +102,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
+    api: API = hass.data[DOMAIN][entry.entry_id]
+
+    _persist_refresh_token(hass, entry, api)
+
     unloaded = all(
         await asyncio.gather(
             *[
@@ -66,7 +114,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ]
         )
     )
-    api: API = hass.data[DOMAIN][entry.entry_id]
     for device in api.get_device_list():
         device.stop_updater()
 

--- a/custom_components/smartrent/__init__.py
+++ b/custom_components/smartrent/__init__.py
@@ -71,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 entry, session, username, password, tfa_token
             )
             _LOGGER.debug("Authenticated using stored refresh token")
-        except (InvalidAuthError, ClientConnectorError, EOFError, Exception) as exc:
+        except Exception as exc:
             _LOGGER.warning(
                 "Refresh token login failed (%s), falling back to full login",
                 type(exc).__name__,

--- a/custom_components/smartrent/const.py
+++ b/custom_components/smartrent/const.py
@@ -5,5 +5,6 @@ CONFIGURATION_URL = "https://control.smartrent.com/login"
 CONF_PASSWORD = "password"
 CONF_USERNAME = "username"
 CONF_TOKEN = "token"
+CONF_REFRESH_TOKEN = "refresh_token"
 PLATFORMS = ["binary_sensor", "climate", "light", "lock", "sensor", "switch"]
 STARTUP_MESSAGE = f"Starting setup for {DOMAIN}"


### PR DESCRIPTION
When a user has 2FA set up on their SmartRent account, this integration will ask them to sign in every time Home Assistant restarts because the session's refresh token is discarded. This change persists the SmartRent API refresh token in the config entry so it can be reused across restarts, eliminating repeated 2FA prompts. If that fails for any reason, it falls back transparently to the original username/password login path.

### Test plan
- [X] Fresh setup with 2FA -- verified initial login works and refresh token is persisted
- [X] Restart HA -- verified re-authentication succeeds via refresh token without requiring a new 2FA code

